### PR TITLE
test: add provided dependency useful to mock cache-resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <gravitee-resource-cache.version>1.5.0-SNAPSHOT</gravitee-resource-cache.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <async-http-client.version>2.0.2</async-http-client.version>
+        <hazelcast.version>4.1.1</hazelcast.version>
     </properties>
 
     <dependencies>
@@ -119,6 +120,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- TODO: remove this when will working on https://github.com/gravitee-io/issues/issues/4898  -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${hazelcast.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Don't forget to remove Hazelcast test dependency when will working on gravitee-io/issues#4898