### PR TITLE
fix: bump gateway api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
 
     <properties>
         <gravitee-bom.version>2.7</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.11</gravitee-gateway-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
@@ -43,7 +44,7 @@
         <gravitee-node.version>2.0.1</gravitee-node.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.3.0</gravitee-resource-cache-provider-api.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.20.0-alpha.2-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
@@ -89,6 +90,11 @@
                 <version>${gravitee-gateway-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.gravitee.reporter</groupId>
+                <artifactId>gravitee-reporter-api</artifactId>
+                <version>${gravitee-reporter-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.gravitee.connector</groupId>
                 <artifactId>gravitee-connector-api</artifactId>
                 <version>${gravitee-connector-api.version}</version>
@@ -106,6 +112,12 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.reporter</groupId>
+            <artifactId>gravitee-reporter-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -213,7 +213,7 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements SecurityPolicy {
         String user = tokenIntrospectionResult.extractUser(oauth2Resource.getUserClaim());
         if (user != null && !user.trim().isEmpty()) {
             ctx.setAttribute(ATTR_USER, user);
-            ctx.request().metrics().setUser(user);
+            ctx.metrics().setUser(user);
         }
 
         List<String> scopes = tokenIntrospectionResult.extractScopes(oauth2Resource.getScopeSeparator());

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -35,13 +35,13 @@ import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.Request;
 import io.gravitee.gateway.jupiter.api.context.Response;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
+import io.gravitee.gateway.jupiter.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.jupiter.core.context.MutableRequest;
 import io.gravitee.gateway.jupiter.core.context.MutableResponse;
-import io.gravitee.gateway.jupiter.reactor.handler.context.DefaultExecutionContext;
 import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
 import io.gravitee.policy.oauth2.introspection.TokenIntrospectionResult;
 import io.gravitee.policy.oauth2.resource.CacheElement;
-import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.gravitee.resource.api.ResourceManager;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
@@ -298,7 +298,7 @@ class Oauth2PolicyTest {
         prepareIntrospection(token, payload, true);
 
         final Metrics metrics = mock(Metrics.class);
-        when(request.metrics()).thenReturn(metrics);
+        when(ctx.metrics()).thenReturn(metrics);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertComplete();


### PR DESCRIPTION

**Description**

Bump gateway api version to use the latest Metric object
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-bump-gateway-api-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/2.0.1-bump-gateway-api-version-SNAPSHOT/gravitee-policy-oauth2-2.0.1-bump-gateway-api-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
