### PR TITLE
fix: clean schema-form to make it compatible with gio-form-json-schema component

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,66 +1,71 @@
 {
-  "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:oauth2:configuration:OAuth2PolicyConfiguration",
-  "properties": {
-    "oauthResource": {
-      "title": "OAuth2 resource",
-      "description": "OAuth2 resource used to validate token. Supports EL.",
-      "type": "string",
-      "x-schema-form": {
-        "event": {
-          "name": "fetch-resources",
-          "regexTypes":  "^oauth2"
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "oauthResource": {
+            "title": "OAuth2 resource",
+            "description": "OAuth2 resource used to validate token. Supports EL.",
+            "type": "string",
+            "x-schema-form": {
+                "event": {
+                    "name": "fetch-resources",
+                    "regexTypes": "^oauth2"
+                },
+                "placeholder": "oauth-resource-name"
+            },
+            "gioConfig": {
+                "uiType": "plan-oauth2-resource"
+            }
         },
-        "placeholder": "oauth-resource-name"
-      }
-    },
-    "oauthCacheResource": {
-      "title": "Cache resource",
-      "description": "Cache resource used to store the tokens.",
-      "type": "string",
-      "x-schema-form": {
-        "event": {
-          "name": "fetch-resources",
-          "regexTypes":  "^cache"
+        "oauthCacheResource": {
+            "title": "Cache resource",
+            "description": "Cache resource used to store the tokens.",
+            "type": "string",
+            "x-schema-form": {
+                "event": {
+                    "name": "fetch-resources",
+                    "regexTypes": "^cache"
+                },
+                "placeholder": "cache-resource-name"
+            },
+            "gioConfig": {
+                "uiType": "plan-cache-resource"
+            }
         },
-        "placeholder": "cache-resource-name"
-      }
+        "extractPayload": {
+            "title": "Extract OAuth2 payload",
+            "description": "Push the token endpoint payload into the 'oauth.payload' context attribute.",
+            "type": "boolean",
+            "default": false
+        },
+        "checkRequiredScopes": {
+            "title": "Check scopes",
+            "description": "Check required scopes to access the resource",
+            "type": "boolean",
+            "default": false
+        },
+        "requiredScopes": {
+            "type": "array",
+            "title": "Required scopes",
+            "description": "List of required scopes to access the resource.",
+            "items": {
+                "type": "string",
+                "title": "Scope"
+            }
+        },
+        "modeStrict": {
+            "title": "Mode strict",
+            "description": "Check scopes with exactly those configured",
+            "type": "boolean",
+            "default": true
+        },
+        "propagateAuthHeader": {
+            "title": "Permit authorization header to the target endpoints",
+            "description": "Allows to propagate Authorization header to the target endpoints",
+            "type": "boolean",
+            "default": true
+        }
     },
-    "extractPayload": {
-      "title": "Extract OAuth2 payload",
-      "description": "Push the token endpoint payload into the 'oauth.payload' context attribute.",
-      "type": "boolean",
-      "default": false
-    },
-    "checkRequiredScopes": {
-      "title": "Check scopes",
-      "description": "Check required scopes to access the resource",
-      "type": "boolean",
-      "default": false
-    },
-    "requiredScopes": {
-      "type": "array",
-      "title": "Required scopes",
-      "description": "List of required scopes to access the resource.",
-      "items": {
-        "type": "string",
-        "title": "Scope"
-      }
-    },
-    "modeStrict": {
-      "title": "Mode strict",
-      "description": "Check scopes with exactly those configured",
-      "type": "boolean",
-      "default": true
-    },
-    "propagateAuthHeader": {
-      "title": "Propagate Authorization header",
-      "description": "Allows to propagate Authorization header to the target endpoints",
-      "type": "boolean",
-      "default": true
-    }
-  },
-  "required": [
-    "oauthResource"
-  ]
+    "required": ["oauthResource"],
+    "additionalProperties": false
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1450

**Description**

Update schema-form to make them compatible with the new gio-form-json-schema component.

to validate these changes it is necessary that it works with the old and the new  UI component 
and also with backend rest-api check

 Old :
 Online checker : https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
 
 New :
 Online checker : https://particles.gravitee.io/?path=/story/components-form-json-schema--string

**Additional context**

PR linked which will be tested with the temporary version in apim

- https://github.com/gravitee-io/gravitee-ui-particles/pull/223
- https://github.com/gravitee-io/gravitee-policy-jwt/pull/92
- https://github.com/gravitee-io/gravitee-policy-apikey/pull/63
- https://github.com/gravitee-io/gravitee-policy-oauth2/pull/68
- https://github.com/gravitee-io/gravitee-api-management/pull/3686

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.1-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/2.1.1-json-schema-SNAPSHOT/gravitee-policy-oauth2-2.1.1-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
