### PR TITLE
fix: simplify unauthorized message

### DIFF
--- a/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3IntegrationTest.java
@@ -42,17 +42,6 @@ public class Oauth2PolicyV3IntegrationTest extends Oauth2PolicyV4EmulationEngine
      */
     @Override
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
-        // FIXME: Use plan instead of `null` to properly handle plan selection in multi-plan context
-        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, null));
-    }
-
-    /**
-     * This overrides 401 response HTTP body content assertion :
-     * - in jupiter, it's "Unauthorized"
-     * - in V3, it's sometimes "Unauthorized", sometimes "access_denied", or empty
-     */
-    @Override
-    protected void assertUnauthorizedResponseBody(String responseBody) {
-        assertThat(responseBody).isIn("Unauthorized", "access_denied", "");
+        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
     }
 }


### PR DESCRIPTION
**Description**

  - to avoid giving too much information, all error will only return Unauthorized as message.
  - The header WWW-Authenticate won't contain any more extra details

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-simplify-error-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/3.0.0-simplify-error-message-SNAPSHOT/gravitee-policy-oauth2-3.0.0-simplify-error-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
