### PR TITLE
Bump `gravitee-parent` to 21.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
**Issue**

NA

**Description**

Bump `gravitee-parent` to 21.0.1
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.2-bump-gravitee-parent-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/2.3.2-bump-gravitee-parent-SNAPSHOT/gravitee-policy-oauth2-2.3.2-bump-gravitee-parent-SNAPSHOT.zip)
  <!-- Version placeholder end -->
