### PR TITLE
Add support for scp node in Oauth2PolicyV3

### DIFF
--- a/src/main/java/io/gravitee/policy/oauth2/introspection/TokenIntrospectionResult.java
+++ b/src/main/java/io/gravitee/policy/oauth2/introspection/TokenIntrospectionResult.java
@@ -84,7 +84,9 @@ public class TokenIntrospectionResult {
     public List<String> extractScopes(String scopeSeparator) {
         if (hasValidPayload()) {
             JsonNode scopesNode = oAuth2ResponseJsonNode.path(OAUTH_PAYLOAD_SCOPE_NODE);
-            if (scopesNode.isMissingNode()) scopesNode = oAuth2ResponseJsonNode.path(OAUTH_PAYLOAD_SCOPE_NODE_LEGACY);
+            if (scopesNode.isMissingNode()) {
+                scopesNode = oAuth2ResponseJsonNode.path(OAUTH_PAYLOAD_SCOPE_NODE_LEGACY);
+            }
             List<String> scopes;
             if (scopesNode instanceof ArrayNode) {
                 Iterator<JsonNode> scopeIterator = scopesNode.elements();

--- a/src/main/java/io/gravitee/policy/oauth2/introspection/TokenIntrospectionResult.java
+++ b/src/main/java/io/gravitee/policy/oauth2/introspection/TokenIntrospectionResult.java
@@ -36,6 +36,7 @@ public class TokenIntrospectionResult {
     private static final Logger LOGGER = LoggerFactory.getLogger(Oauth2Policy.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     public static final String OAUTH_PAYLOAD_SCOPE_NODE = "scope";
+    public static final String OAUTH_PAYLOAD_SCOPE_NODE_LEGACY = "scp";
     public static final String OAUTH_PAYLOAD_CLIENT_ID_NODE = "client_id";
     public static final String OAUTH_PAYLOAD_SUB_NODE = "sub";
     public static final String OAUTH_PAYLOAD_EXP = "exp";
@@ -83,6 +84,7 @@ public class TokenIntrospectionResult {
     public List<String> extractScopes(String scopeSeparator) {
         if (hasValidPayload()) {
             JsonNode scopesNode = oAuth2ResponseJsonNode.path(OAUTH_PAYLOAD_SCOPE_NODE);
+            if (scopesNode.isMissingNode()) scopesNode = oAuth2ResponseJsonNode.path(OAUTH_PAYLOAD_SCOPE_NODE_LEGACY);
             List<String> scopes;
             if (scopesNode instanceof ArrayNode) {
                 Iterator<JsonNode> scopeIterator = scopesNode.elements();

--- a/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
@@ -57,7 +57,7 @@ public class Oauth2PolicyV3 {
 
     public static final String BEARER_AUTHORIZATION_TYPE = "Bearer";
     public static final String OAUTH_PAYLOAD_SCOPE_NODE = "scope";
-    private static final String OAUTH_PAYLOAD_SCOPE_NODE_LEGACY = "scp";
+    public static final String OAUTH_PAYLOAD_SCOPE_NODE_LEGACY = "scp";
     public static final String OAUTH_PAYLOAD_CLIENT_ID_NODE = "client_id";
     public static final String OAUTH_PAYLOAD_SUB_NODE = "sub";
     public static final String OAUTH_PAYLOAD_EXP = "exp";
@@ -292,7 +292,9 @@ public class Oauth2PolicyV3 {
 
     protected static List<String> extractScopes(JsonNode oauthResponseNode, String scopeSeparator) {
         JsonNode scopesNode = oauthResponseNode.path(OAUTH_PAYLOAD_SCOPE_NODE);
-        if (scopesNode.isMissingNode()) scopesNode = oauthResponseNode.path(OAUTH_PAYLOAD_SCOPE_NODE_LEGACY);
+        if (scopesNode.isMissingNode()) {
+            scopesNode = oauthResponseNode.path(OAUTH_PAYLOAD_SCOPE_NODE_LEGACY);
+        }
         List<String> scopes;
 
         if (scopesNode instanceof ArrayNode) {

--- a/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
@@ -57,6 +57,7 @@ public class Oauth2PolicyV3 {
 
     public static final String BEARER_AUTHORIZATION_TYPE = "Bearer";
     public static final String OAUTH_PAYLOAD_SCOPE_NODE = "scope";
+    private static final String OAUTH_PAYLOAD_SCOPE_NODE_LEGACY = "scp";
     public static final String OAUTH_PAYLOAD_CLIENT_ID_NODE = "client_id";
     public static final String OAUTH_PAYLOAD_SUB_NODE = "sub";
     public static final String OAUTH_PAYLOAD_EXP = "exp";
@@ -291,7 +292,7 @@ public class Oauth2PolicyV3 {
 
     protected static List<String> extractScopes(JsonNode oauthResponseNode, String scopeSeparator) {
         JsonNode scopesNode = oauthResponseNode.path(OAUTH_PAYLOAD_SCOPE_NODE);
-
+        if (scopesNode.isMissingNode()) scopesNode = oauthResponseNode.path(OAUTH_PAYLOAD_SCOPE_NODE_LEGACY);
         List<String> scopes;
 
         if (scopesNode instanceof ArrayNode) {

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -289,6 +289,20 @@ class Oauth2PolicyTest {
     }
 
     @Test
+    void shouldCompleteWhenGoodIntrospectionWithClientIdUsingScpKey() throws IOException {
+        final String token = prepareToken();
+        prepareOauth2Resource();
+
+        prepareIntrospection(token, readResource("/io/gravitee/policy/oauth2/oauth2-response10.json"), true);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        verify(ctx).setAttribute(Oauth2Policy.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
+        verify(ctx).setAttribute(ATTR_USER_ROLES, List.of("read", "write", "admin"));
+    }
+
+    @Test
     void shouldCompleteWithUser() throws IOException {
         final String user = "my-user";
         final String token = prepareToken();

--- a/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3Test.java
@@ -288,6 +288,14 @@ class Oauth2PolicyV3Test {
     }
 
     @Test
+    void shouldValidScopes_stringOfScopes_scpKey() throws IOException {
+        JsonNode jsonNode = readJsonResource("/io/gravitee/policy/oauth2/oauth2-response10.json");
+        Collection<String> scopes = Oauth2PolicyV3.extractScopes(jsonNode, DEFAULT_OAUTH_SCOPE_SEPARATOR);
+        boolean valid = Oauth2PolicyV3.hasRequiredScopes(scopes, Collections.singletonList("read"), false);
+        Assertions.assertTrue(valid);
+    }
+
+    @Test
     void shouldValidScopes_stringOfScopes_moreOauthScope() throws IOException {
         JsonNode jsonNode = readJsonResource("/io/gravitee/policy/oauth2/oauth2-response08.json");
         Collection<String> scopes = Oauth2PolicyV3.extractScopes(jsonNode, DEFAULT_OAUTH_SCOPE_SEPARATOR);

--- a/src/test/resources/io/gravitee/policy/oauth2/oauth2-response10.json
+++ b/src/test/resources/io/gravitee/policy/oauth2/oauth2-response10.json
@@ -1,0 +1,4 @@
+{
+  "client_id": "my-client-id",
+  "scp": "read write admin"
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/9114 
https://gravitee.atlassian.net/browse/APIM-2130

**Description**

Backport https://github.com/gravitee-io/gravitee-policy-oauth2/pull/70 on `2.0.x`

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-add-scp-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/2.0.1-add-scp-SNAPSHOT/gravitee-policy-oauth2-2.0.1-add-scp-SNAPSHOT.zip)
  <!-- Version placeholder end -->
