### PR TITLE
fix: properly handle token extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.7</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.9</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-node.version>3.1.0-alpha.10</gravitee-node.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>

--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -101,7 +101,7 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements SecurityPolicy {
                 if (introspectionResult.hasClientId()) {
                     return Maybe.just(SecurityToken.forClientId(introspectionResult.getClientId()));
                 }
-                return Maybe.empty();
+                return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CLIENT_ID));
             });
     }
 

--- a/src/main/java/io/gravitee/policy/oauth2/utils/TokenExtractor.java
+++ b/src/main/java/io/gravitee/policy/oauth2/utils/TokenExtractor.java
@@ -44,12 +44,24 @@ public class TokenExtractor {
      *
      * If no access token has been found, an {@link Optional#empty()} is returned.
      *
-     * @param request the request to extract the JWT token from.
+     * @param request the request to extract the access token from.
      *
      * @return the access token as string, {@link Optional#empty()} if no token has been found.
      */
     public static Optional<String> extract(HttpRequest request) {
         return extractFromHeaders(request.headers()).or(() -> extractFromParameters(request.parameters()));
+    }
+
+    /**
+     * @deprecated kept for v3
+     *
+     * @param request the request to extract the JWT token from.
+     * @return the access token as string or <code>null</code> if no token has been found.
+     * @see #extract(HttpRequest)
+     */
+    @Deprecated
+    public static String extract(io.gravitee.gateway.api.Request request) {
+        return extractFromHeaders(request.headers()).or(() -> extractFromParameters(request.parameters())).orElse(null);
     }
 
     private static Optional<String> extractFromHeaders(HttpHeaders headers) {
@@ -67,7 +79,6 @@ public class TokenExtractor {
                 }
             }
         }
-
         return Optional.empty();
     }
 

--- a/src/test/java/io/gravitee/policy/oauth2/DummyOAuth2Resource.java
+++ b/src/test/java/io/gravitee/policy/oauth2/DummyOAuth2Resource.java
@@ -46,6 +46,8 @@ public class DummyOAuth2Resource extends OAuth2Resource<DummyOAuth2Resource.Dumm
             response = new OAuth2Response(true, "{this _is _invalid json");
         } else if (TOKEN_FAIL.equals(accessToken)) {
             response = new OAuth2Response(false, null);
+        } else {
+            response = new OAuth2Response(false, null);
         }
 
         responseHandler.handle(response);

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyV4EmulationEngineIntegrationTest.java
@@ -102,6 +102,18 @@ public class Oauth2PolicyV4EmulationEngineIntegrationTest extends AbstractPolicy
     }
 
     @Test
+    @DisplayName("Should receive 401 - Unauthorized when calling with a empty Authorization Header")
+    void shouldGet401_ifEmptyToken(HttpClient client) throws InterruptedException {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        Single<HttpClientResponse> httpClientResponse = client
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> request.putHeader("Authorization", "Bearer").rxSend());
+
+        assert401unauthorized(httpClientResponse);
+    }
+
+    @Test
     @DisplayName("Should receive 401 - Unauthorized when calling with a wrong Authorization Header")
     void shouldGet401_ifWrongToken(HttpClient client) throws InterruptedException {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));

--- a/src/test/java/io/gravitee/policy/oauth2/utils/TokenExtractorTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/utils/TokenExtractorTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.oauth2.utils;
+
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.policy.jwt.utils.TokenExtractor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class TokenExtractorTest {
+
+    @Mock
+    private Request request;
+
+    @Test
+    void should_not_extract_with__no_authorization_header() {
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
+
+        String token = io.gravitee.policy.jwt.utils.TokenExtractor.extract(request);
+
+        Assertions.assertNull(token);
+    }
+
+    @Test
+    void should_not_extract_with_unknown_authorization_header() {
+        String jwt = "dummy-token";
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", "Basic " + jwt);
+        when(request.headers()).thenReturn(headers);
+
+        String token = io.gravitee.policy.jwt.utils.TokenExtractor.extract(request);
+        Assertions.assertNull(token);
+    }
+
+    @Test
+    void should_extract_with_authorization_header_and_empty_bearer() {
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", io.gravitee.policy.jwt.utils.TokenExtractor.BEARER);
+        when(request.headers()).thenReturn(headers);
+
+        String token = io.gravitee.policy.jwt.utils.TokenExtractor.extract(request);
+        Assertions.assertNotNull(token);
+        Assertions.assertEquals("", token);
+    }
+
+    @Test
+    void should_extract_with_authorization_header_and_bearer() {
+        String jwt = "dummy-token";
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", io.gravitee.policy.jwt.utils.TokenExtractor.BEARER + ' ' + jwt);
+        when(request.headers()).thenReturn(headers);
+
+        String token = io.gravitee.policy.jwt.utils.TokenExtractor.extract(request);
+
+        Assertions.assertNotNull(token);
+        Assertions.assertEquals(jwt, token);
+    }
+
+    @Test
+    void should_extract_from_insensitive_header() {
+        String jwt = "dummy-token";
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", "bearer " + jwt);
+        when(request.headers()).thenReturn(headers);
+
+        String token = io.gravitee.policy.jwt.utils.TokenExtractor.extract(request);
+
+        Assertions.assertNotNull(token);
+        Assertions.assertEquals(jwt, token);
+    }
+
+    @Test
+    void should_extract_from_query_parameter() {
+        String jwt = "dummy-token";
+
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(io.gravitee.policy.jwt.utils.TokenExtractor.ACCESS_TOKEN, jwt);
+        when(request.parameters()).thenReturn(parameters);
+
+        String token = TokenExtractor.extract(request);
+
+        Assertions.assertNotNull(token);
+        Assertions.assertEquals(jwt, token);
+    }
+
+    @Test
+    void should_extract_from_empty_query_parameter() {
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add(io.gravitee.policy.jwt.utils.TokenExtractor.ACCESS_TOKEN, "");
+        when(request.parameters()).thenReturn(parameters);
+
+        String token = TokenExtractor.extract(request);
+
+        Assertions.assertNotNull(token);
+        Assertions.assertEquals("", token);
+    }
+}


### PR DESCRIPTION
**Description**

Properly handle token extraction

- no Authorization header will not return any security token
- no Bearer security schema value will not return a security token (Authorization: Basic 123456)
- Empty Bearer will return an invalid security token
- token without client_id will now return an invalid Security Token

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-properly-handle-empty-token-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/3.0.0-properly-handle-empty-token-SNAPSHOT/gravitee-policy-oauth2-3.0.0-properly-handle-empty-token-SNAPSHOT.zip)
  <!-- Version placeholder end -->
