### PR TITLE
fix: always remove AUTHORIZATION header (if needed) before policyChain.doNext

### DIFF
--- a/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
@@ -142,10 +142,6 @@ public class Oauth2PolicyV3 {
             // Validate access token
             oauth2.introspect(accessToken, handleResponse(policyChain, request, response, executionContext, null));
         }
-
-        if (!oAuth2PolicyConfiguration.isPropagateAuthHeader()) {
-            request.headers().remove(HttpHeaderNames.AUTHORIZATION);
-        }
     }
 
     Handler<OAuth2Response> handleResponse(
@@ -253,6 +249,10 @@ public class Oauth2PolicyV3 {
                 element.setTimeToLive(Long.valueOf(ttl).intValue());
             }
             cacheResource.getCache(executionContext).put(element);
+        }
+
+        if (!oAuth2PolicyConfiguration.isPropagateAuthHeader()) {
+            request.headers().remove(HttpHeaderNames.AUTHORIZATION);
         }
 
         // Continue chaining


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2856

**Description**

Previously, in the case where the request was correctly cached, the handleSuccess was called first, which executed the chain without deleting the header. And at the end the header is removed.
So it wasn't possible to overload the header with a transform-header for example.
Now the header is removed before the chain is executed.

📝  With the Jupiter V4 engine, this bug does not occur.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-APIM-2856-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/2.0.2-APIM-2856-SNAPSHOT/gravitee-policy-oauth2-2.0.2-APIM-2856-SNAPSHOT.zip)
  <!-- Version placeholder end -->
