### PR TITLE
fix: always remove AUTHORIZATION header (if needed) before policyChain.doNext

### DIFF
--- a/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
@@ -144,10 +144,6 @@ public class Oauth2PolicyV3 {
             // Validate access token
             oauth2.introspect(accessToken, handleResponse(policyChain, request, response, executionContext, null));
         }
-
-        if (!oAuth2PolicyConfiguration.isPropagateAuthHeader()) {
-            request.headers().remove(HttpHeaderNames.AUTHORIZATION);
-        }
     }
 
     Handler<OAuth2Response> handleResponse(
@@ -238,6 +234,10 @@ public class Oauth2PolicyV3 {
                 element.setTimeToLive(Long.valueOf(ttl).intValue());
             }
             cacheResource.getCache(executionContext).put(element);
+        }
+
+        if (!oAuth2PolicyConfiguration.isPropagateAuthHeader()) {
+            request.headers().remove(HttpHeaderNames.AUTHORIZATION);
         }
 
         // Continue chaining

--- a/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3Test.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.policy.v3.oauth2;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.argThat;
@@ -416,6 +417,7 @@ class Oauth2PolicyV3Test {
         HttpHeaders httpHeaders = mock(HttpHeaders.class);
 
         Oauth2PolicyV3 policy = new Oauth2PolicyV3(oAuth2PolicyConfiguration);
+        when(oAuth2PolicyConfiguration.isPropagateAuthHeader()).thenReturn(true);
         when(oAuth2PolicyConfiguration.getOauthResource()).thenReturn("oauth2");
         when(mockExecutionContext.getComponent(ResourceManager.class)).thenReturn(resourceManager);
         when(resourceManager.getResource(oAuth2PolicyConfiguration.getOauthResource(), OAuth2Resource.class))
@@ -433,6 +435,7 @@ class Oauth2PolicyV3Test {
 
     @Test
     void shouldValidate_goodIntrospection_withClientId() throws IOException {
+        when(oAuth2PolicyConfiguration.isPropagateAuthHeader()).thenReturn(true);
         when(oAuth2PolicyConfiguration.isExtractPayload()).thenReturn(true);
 
         Oauth2PolicyV3 policy = new Oauth2PolicyV3(oAuth2PolicyConfiguration);
@@ -465,6 +468,7 @@ class Oauth2PolicyV3Test {
 
     @Test
     void shouldValidate_goodIntrospection_withClientId_validScopes() throws IOException {
+        when(oAuth2PolicyConfiguration.isPropagateAuthHeader()).thenReturn(true);
         when(oAuth2PolicyConfiguration.isCheckRequiredScopes()).thenReturn(true);
         when(mockExecutionContext.getComponent(ResourceManager.class)).thenReturn(resourceManager);
         when(resourceManager.getResource(oAuth2PolicyConfiguration.getOauthResource(), OAuth2Resource.class))
@@ -483,6 +487,7 @@ class Oauth2PolicyV3Test {
 
     @Test
     void shouldValidate_goodIntrospection_withCache() throws IOException {
+        when(oAuth2PolicyConfiguration.isPropagateAuthHeader()).thenReturn(true);
         when(oAuth2PolicyConfiguration.isCheckRequiredScopes()).thenReturn(true);
         when(mockExecutionContext.getComponent(ResourceManager.class)).thenReturn(resourceManager);
         when(resourceManager.getResource(oAuth2PolicyConfiguration.getOauthResource(), OAuth2Resource.class))
@@ -503,6 +508,38 @@ class Oauth2PolicyV3Test {
 
         String payload = readResource("/io/gravitee/policy/oauth2/oauth2-response04.json");
         handler.handle(new OAuth2Response(true, payload));
+
+        verify(mockExecutionContext).setAttribute(Oauth2PolicyV3.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
+        verify(mockPolicychain).doNext(mockRequest, mockResponse);
+        verify(cache).put(any(Element.class));
+    }
+
+    @Test
+    void shouldValidate_goodIntrospection_withCache_without_auth_propagation() throws IOException {
+        when(oAuth2PolicyConfiguration.isPropagateAuthHeader()).thenReturn(false);
+        when(oAuth2PolicyConfiguration.isCheckRequiredScopes()).thenReturn(true);
+        when(mockExecutionContext.getComponent(ResourceManager.class)).thenReturn(resourceManager);
+        when(resourceManager.getResource(oAuth2PolicyConfiguration.getOauthResource(), OAuth2Resource.class))
+            .thenReturn(customOAuth2Resource);
+        when(customOAuth2Resource.getScopeSeparator()).thenReturn(DEFAULT_OAUTH_SCOPE_SEPARATOR);
+        when(mockRequest.headers()).thenReturn(HttpHeaders.create().set("Authorization", "Bearer " + UUID.randomUUID()));
+
+        Cache cache = mock(Cache.class);
+        when(customCacheResource.getCache(any(ExecutionContext.class))).thenReturn(cache);
+
+        Oauth2PolicyV3 policy = new Oauth2PolicyV3(oAuth2PolicyConfiguration);
+        Handler<OAuth2Response> handler = policy.handleResponse(
+            mockPolicychain,
+            mockRequest,
+            mockResponse,
+            mockExecutionContext,
+            customCacheResource
+        );
+
+        String payload = readResource("/io/gravitee/policy/oauth2/oauth2-response04.json");
+        handler.handle(new OAuth2Response(true, payload));
+
+        assertNull(mockRequest.headers().get("Authorization"));
 
         verify(mockExecutionContext).setAttribute(Oauth2PolicyV3.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
         verify(mockPolicychain).doNext(mockRequest, mockResponse);


### PR DESCRIPTION

**Issue**

Next to : https://github.com/gravitee-io/gravitee-policy-oauth2/pull/93

**Description**

See main PR

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-3-0-x-APIM-2856-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/3.0.1-3-0-x-APIM-2856-SNAPSHOT/gravitee-policy-oauth2-3.0.1-3-0-x-APIM-2856-SNAPSHOT.zip)
  <!-- Version placeholder end -->
