### PR TITLE
Fail with an error if error during security token extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-oauth2</artifactId>
-    <version>3.0.3</version>
+    <version>3.0.4-apim-3382-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - OAuth2</name>
     <description>Check access token validity during request processing using token introspection</description>
@@ -39,9 +39,9 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-node.version>4.0.0</gravitee-node.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.0.0</gravitee-apim.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <guava.version>31.1-jre</guava.version>

--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -100,6 +100,9 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements SecurityPolicy {
                 if (introspectionResult.hasClientId()) {
                     return Maybe.just(SecurityToken.forClientId(introspectionResult.getClientId()));
                 }
+                if (introspectionResult.getOauth2ResponseThrowable() != null) {
+                    return Maybe.error(introspectionResult.getOauth2ResponseThrowable());
+                }
                 return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CLIENT_ID));
             });
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3382

**Description**

Depends on https://github.com/gravitee-io/gravitee-gateway-api/pull/219

* Fail with an error if error during security token extraction
* Re-enable disabled tests and fix them
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.4-apim-3382-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/3.0.4-apim-3382-SNAPSHOT/gravitee-policy-oauth2-3.0.4-apim-3382-SNAPSHOT.zip)
  <!-- Version placeholder end -->
