### PR TITLE
Update policy for kafka gateway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,9 @@
-**Issue**
+## Issue
 
-https://gravitee.atlassian.net/browse/APIM-XXXX
+https://gravitee.atlassian.net/browse/XXXXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
-
-<!-- Add any other context about the PR here -->
-<!-- It can be links to other PRs or docs or drawing -->
-<!-- Or reproduction steps in case of bug fix -->
+## Additional context

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-    "extends": ["config:base", ":label(dependencies)"],
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "chore"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["major"],
-            "semanticCommitType": "chore"
-        }
-    ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-oauth2</artifactId>
-    <version>3.0.5</version>
+    <version>4.0.0-APIM-7143-impl-security-chain-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - OAuth2</name>
     <description>Check access token validity during request processing using token introspection</description>
@@ -30,21 +30,11 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.2.2</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.2.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-apim.version>4.0.0</gravitee-apim.version>
-        <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
-        <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
-        <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
-        <guava.version>31.1-jre</guava.version>
+        <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
 
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
@@ -57,31 +47,11 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.resource</groupId>
-                <artifactId>gravitee-resource-api</artifactId>
-                <version>${gravitee-resource-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.common</groupId>
-                <artifactId>gravitee-common</artifactId>
-                <version>${gravitee-common.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -111,13 +81,11 @@
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-oauth2-provider-api</artifactId>
-            <version>${gravitee-resource-oauth2-provider-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-cache-provider-api</artifactId>
-            <version>${gravitee-resource-cache-provider-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -149,7 +117,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>${nimbus-jose-jwt.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test scope -->
@@ -182,7 +150,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>

--- a/src/main/java/io/gravitee/policy/oauth2/introspection/TokenIntrospectionResult.java
+++ b/src/main/java/io/gravitee/policy/oauth2/introspection/TokenIntrospectionResult.java
@@ -40,6 +40,7 @@ public class TokenIntrospectionResult {
     public static final String OAUTH_PAYLOAD_CLIENT_ID_NODE = "client_id";
     public static final String OAUTH_PAYLOAD_SUB_NODE = "sub";
     public static final String OAUTH_PAYLOAD_EXP = "exp";
+    public static final String OAUTH_PAYLOAD_ISSUED_AT = "iat";
 
     private String oauth2ResponsePayload;
     private boolean success;
@@ -79,6 +80,17 @@ public class TokenIntrospectionResult {
 
     public boolean hasExpirationTime() {
         return getExpirationTime() != null;
+    }
+
+    public Long getIssuedAtTime() {
+        if (hasValidPayload() && oAuth2ResponseJsonNode.has(OAUTH_PAYLOAD_ISSUED_AT)) {
+            return oAuth2ResponseJsonNode.get(OAUTH_PAYLOAD_ISSUED_AT).asLong();
+        }
+        return null;
+    }
+
+    public boolean hasIssuedAtTime() {
+        return getIssuedAtTime() != null;
     }
 
     public List<String> extractScopes(String scopeSeparator) {

--- a/src/main/java/io/gravitee/policy/oauth2/utils/TokenExtractor.java
+++ b/src/main/java/io/gravitee/policy/oauth2/utils/TokenExtractor.java
@@ -19,9 +19,15 @@ import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import java.util.List;
 import java.util.Optional;
+import javax.security.auth.callback.Callback;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerExtensionsValidatorCallback;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -36,6 +42,43 @@ public class TokenExtractor {
     static final String ACCESS_TOKEN = "access_token";
 
     /**
+     * Extract an access token from a {@link BaseExecutionContext}.
+     * If no access token has been found, an {@link Optional#empty()} is returned.
+     *
+     * @param ctx the execution context to extract the access token from.
+     *
+     * @return the access token as string, {@link Optional#empty()} if no token has been found.
+     */
+    public static Optional<String> extract(BaseExecutionContext ctx) {
+        if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+            return extract(httpPlainExecutionContext.request());
+        }
+        KafkaConnectionContext kafkaConnectionContext = (KafkaConnectionContext) ctx;
+        return extract(kafkaConnectionContext.callbacks());
+    }
+
+    /**
+     * Extract an access token from a {@link javax.security.auth.callback.Callback} array.
+     * If no access token has been found, an {@link Optional#empty()} is returned.
+     *
+     * @param callbacks the callbacks to extract the access token from.
+     *
+     * @return the access token as string, {@link Optional#empty()} if no token has been found.
+     */
+    private static Optional<String> extract(Callback[] callbacks) {
+        for (Callback callback : callbacks) {
+            if (callback instanceof OAuthBearerValidatorCallback oAuthCallback) {
+                String token = oAuthCallback.tokenValue();
+                return Optional.of(token);
+            } else if (callback instanceof OAuthBearerExtensionsValidatorCallback oAuthCallback) {
+                String token = oAuthCallback.token().value();
+                return Optional.of(token);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Extract an access token from a {@link Request} headers or parameters.
      * <ul>
      *     <li>Get the first <code>Authorization</code> bearer header</li>
@@ -48,7 +91,7 @@ public class TokenExtractor {
      *
      * @return the access token as string, {@link Optional#empty()} if no token has been found.
      */
-    public static Optional<String> extract(HttpPlainRequest request) {
+    private static Optional<String> extract(HttpPlainRequest request) {
         return extractFromHeaders(request.headers()).or(() -> extractFromParameters(request.parameters()));
     }
 

--- a/src/main/java/io/gravitee/policy/oauth2/utils/TokenExtractor.java
+++ b/src/main/java/io/gravitee/policy/oauth2/utils/TokenExtractor.java
@@ -16,10 +16,10 @@
 package io.gravitee.policy.oauth2.utils;
 
 import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpRequest;
-import io.gravitee.gateway.reactive.api.context.Request;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.util.ObjectUtils;
@@ -48,7 +48,7 @@ public class TokenExtractor {
      *
      * @return the access token as string, {@link Optional#empty()} if no token has been found.
      */
-    public static Optional<String> extract(HttpRequest request) {
+    public static Optional<String> extract(HttpPlainRequest request) {
         return extractFromHeaders(request.headers()).or(() -> extractFromParameters(request.parameters()));
     }
 
@@ -57,7 +57,7 @@ public class TokenExtractor {
      *
      * @param request the request to extract the JWT token from.
      * @return the access token as string or <code>null</code> if no token has been found.
-     * @see #extract(HttpRequest)
+     * @see #extract(HttpPlainRequest)
      */
     @Deprecated
     public static String extract(io.gravitee.gateway.api.Request request) {

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -55,6 +55,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
@@ -436,7 +437,7 @@ class Oauth2PolicyTest {
 
     private void prepareCacheResource() {
         when(configuration.getOauthCacheResource()).thenReturn(OAUTH_CACHE_RESOURCE);
-        when(cacheResource.getCache(any(GenericExecutionContext.class))).thenReturn(cache);
+        when(cacheResource.getCache(any(BaseExecutionContext.class))).thenReturn(cache);
         when(resourceManager.getResource(OAUTH_CACHE_RESOURCE, CacheResource.class)).thenReturn(cacheResource);
     }
 

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -54,9 +54,10 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
-import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
@@ -107,13 +108,13 @@ class Oauth2PolicyTest {
     private OAuth2PolicyConfiguration configuration;
 
     @Mock
-    private Request request;
+    private HttpPlainRequest request;
 
     @Mock
-    private Response response;
+    private HttpPlainResponse response;
 
-    @Mock
-    private HttpExecutionContext ctx;
+    @Mock(extraInterfaces = GenericExecutionContext.class)
+    private HttpPlainExecutionContext ctx;
 
     @Mock
     private ResourceManager resourceManager;
@@ -435,7 +436,7 @@ class Oauth2PolicyTest {
 
     private void prepareCacheResource() {
         when(configuration.getOauthCacheResource()).thenReturn(OAUTH_CACHE_RESOURCE);
-        when(cacheResource.getCache(any(HttpExecutionContext.class))).thenReturn(cache);
+        when(cacheResource.getCache(any(GenericExecutionContext.class))).thenReturn(cache);
         when(resourceManager.getResource(OAUTH_CACHE_RESOURCE, CacheResource.class)).thenReturn(cacheResource);
     }
 
@@ -565,7 +566,7 @@ class Oauth2PolicyTest {
         final String payload = readJsonResource("/io/gravitee/policy/oauth2/oauth2-response09.json").toString();
         prepareIntrospection(token, payload, true);
 
-        HttpExecutionContext ctx = new DefaultExecutionContext(mock(MutableRequest.class), mock(MutableResponse.class));
+        HttpPlainExecutionContext ctx = new DefaultExecutionContext(mock(MutableRequest.class), mock(MutableResponse.class));
         TestObserver<TokenIntrospectionResult> result1 = cut.introspectAccessToken(ctx, token, oAuth2Resource).test();
         TestObserver<TokenIntrospectionResult> result2 = cut.introspectAccessToken(ctx, token, oAuth2Resource).test();
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7143

**Description**

- use new HttpSecurityPolicy and BaseExecutionContext interface (BREAKING CHANGE: requires APIM 4.6+)
- implement kafka policy
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-APIM-7143-impl-security-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/4.0.0-APIM-7143-impl-security-chain-SNAPSHOT/gravitee-policy-oauth2-4.0.0-APIM-7143-impl-security-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
