### PR TITLE
fix: invoke callback and complete on auth failure

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,9 +37,10 @@ $ curl -H "Authorization: Bearer |accessToken|" \
 
 |===
 | Plugin version | APIM version
+| 4.x            | 4.6.x to latest
+| 3.x            | 4.0.x to 4.5.x
+| 2.x            | 3.20.x
 | 1.x            | Up to 3.19.x
-| 2.0.x          | 3.20.x
-| 3.x            | 4.x to latest
 |===
 
 == Attributes


### PR DESCRIPTION
**Issue**

N/A

**Description**

We must invoke the callback with a specific error in case of authentication failed.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-fix-complete-on-authentication-failure-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/4.0.0-fix-complete-on-authentication-failure-SNAPSHOT/gravitee-policy-oauth2-4.0.0-fix-complete-on-authentication-failure-SNAPSHOT.zip)
  <!-- Version placeholder end -->
