### PR TITLE
feat: set a max value for kafka token lifetime

### DIFF
--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -406,10 +406,7 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
 
         return ctx
             .getComponent(ResourceManager.class)
-            .getResource(
-                ctx.getTemplateEngine().getValue(oAuth2PolicyConfiguration.getOauthResource(), String.class),
-                OAuth2Resource.class
-            );
+            .getResource(ctx.getTemplateEngine().evalNow(oAuth2PolicyConfiguration.getOauthResource(), String.class), OAuth2Resource.class);
     }
 
     /**

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -588,7 +588,7 @@ class Oauth2PolicyTest {
 
     private void prepareOauth2Resource() {
         when(configuration.getOauthResource()).thenReturn(OAUTH_RESOURCE);
-        when(templateEngine.getValue(OAUTH_RESOURCE, String.class)).thenReturn(OAUTH_RESOURCE);
+        when(templateEngine.evalNow(OAUTH_RESOURCE, String.class)).thenReturn(OAUTH_RESOURCE);
         when(resourceManager.getResource(OAUTH_RESOURCE, OAuth2Resource.class)).thenReturn(oAuth2Resource);
         lenient().when(oAuth2Resource.getScopeSeparator()).thenReturn(DEFAULT_OAUTH_SCOPE_SEPARATOR);
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7143

**Description**

Set a max value for kafka token lifetime.
It's required to avoid kafka client re-authent storm
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-set-a-max-lifetime-for-kafka-outhbearer-token-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/4.0.0-set-a-max-lifetime-for-kafka-outhbearer-token-SNAPSHOT/gravitee-policy-oauth2-4.0.0-set-a-max-lifetime-for-kafka-outhbearer-token-SNAPSHOT.zip)
  <!-- Version placeholder end -->
