### PR TITLE
fix: condition `.metrics()` use only if ctx is http

### DIFF
--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -156,6 +156,7 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
             })
             .andThen(
                 Completable.fromRunnable(() -> {
+                    ctx.metrics().setUser(ctx.getAttribute(ATTR_USER));
                     if (!oAuth2PolicyConfiguration.isPropagateAuthHeader()) {
                         ctx.request().headers().remove(HttpHeaderNames.AUTHORIZATION);
                     }
@@ -296,7 +297,6 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
         String user = tokenIntrospectionResult.extractUser(oauth2Resource.getUserClaim());
         if (user != null && !user.trim().isEmpty()) {
             ctx.setAttribute(ATTR_USER, user);
-            ctx.metrics().setUser(user);
         }
 
         List<String> scopes = tokenIntrospectionResult.extractScopes(oauth2Resource.getScopeSeparator());

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -138,6 +138,9 @@ class Oauth2PolicyTest {
     @Mock
     private Cache cache;
 
+    @Mock
+    private Metrics metrics;
+
     private Oauth2Policy cut;
 
     @BeforeEach
@@ -151,6 +154,9 @@ class Oauth2PolicyTest {
 
         lenient().when(ctx.response()).thenReturn(response);
         lenient().when(response.headers()).thenReturn(responseHeaders);
+
+        lenient().when(ctx.metrics()).thenReturn(metrics);
+        lenient().when(ctx.getAttribute(ATTR_USER)).thenReturn("my-user");
 
         cut = new Oauth2Policy(configuration);
     }


### PR DESCRIPTION
## Issue
n/a

## Description

To be able to use [this](https://github.com/gravitee-io/gravitee-gateway-api/pull/280) changes into APIM 


## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-refactor-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/4.0.1-refactor-context-SNAPSHOT/gravitee-policy-oauth2-4.0.1-refactor-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
