### PR TITLE
fix: include the scopes when returning the protected resource metadata from the oauth2 policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,9 @@
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-oauth2-provider-api</artifactId>
-            <scope>provided</scope>
+            <!-- Version specified to avoid a breaking change. Once the versions of APIM under 4.12 will not be maintained anymore
+                    we can move back to scope provided and remove the version. -->
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.resource</groupId>

--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -251,7 +251,11 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
                 uri.getRawAuthority() +
                 uri.getRawPath().substring(WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH.length());
 
-            OAuth2ResourceMetadata resourceMetadata = oauth2Resource.getProtectedResourceMetadata(protectedResourceUri);
+            List<String> scopesSupported = oAuth2PolicyConfiguration.getRequiredScopes() != null
+                ? oAuth2PolicyConfiguration.getRequiredScopes()
+                : List.of();
+            OAuth2ResourceMetadata resourceMetadata = oauth2Resource.getProtectedResourceMetadata(protectedResourceUri, scopesSupported);
+
             try {
                 String message = MAPPER.writeValueAsString(resourceMetadata);
                 ctx.response().body(Buffer.buffer(message));

--- a/src/test/java/io/gravitee/policy/oauth2/DummyOAuth2Resource.java
+++ b/src/test/java/io/gravitee/policy/oauth2/DummyOAuth2Resource.java
@@ -58,7 +58,7 @@ public class DummyOAuth2Resource extends OAuth2Resource<DummyOAuth2Resource.Dumm
     public void userInfo(String accessToken, Handler<UserInfoResponse> responseHandler) {}
 
     @Override
-    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri) {
+    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri, List<String> scopesSupported) {
         return new OAuth2ResourceMetadata(protectedResourceUri, List.of("https://some.keycloak.com/realms/test"), List.of("read", "write"));
     }
 


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13671
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.2.1-apim-13671-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/5.2.1-apim-13671-SNAPSHOT/gravitee-policy-oauth2-5.2.1-apim-13671-SNAPSHOT.zip)
  <!-- Version placeholder end -->
