### PR TITLE
feat(oauth2): use async Cache API (APIM-13700)

### DIFF
--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -43,7 +43,6 @@ import io.gravitee.policy.v3.oauth2.Oauth2PolicyV3;
 import io.gravitee.resource.api.ResourceManager;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
-import io.gravitee.resource.cache.api.Element;
 import io.gravitee.resource.oauth2.api.OAuth2Resource;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
@@ -390,23 +389,22 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
             return Single.just(tokenIntrospectionCache.get(accessToken, oauth2Resource).get());
         }
 
-        // find introspection in policy cache
+        // find introspection in policy cache (async — must not block the event loop)
         final Cache policyCache = getPolicyTokenIntrospectionCache(ctx);
-        if (policyCache != null) {
-            Element element = policyCache.get(accessToken);
-            if (element != null) {
+        Maybe<TokenIntrospectionResult> cached = policyCache == null
+            ? Maybe.empty()
+            : Maybe.fromCompletionStage(policyCache.getAsync(accessToken).toCompletionStage()).map(element -> {
                 log.debug("Token as already been introspected in the policy level cache. Re-using cached response.");
-                return Single.just(new TokenIntrospectionResult((String) element.value()));
-            }
-        }
+                return new TokenIntrospectionResult((String) element.value());
+            });
 
-        // or execute token introspection
-        Single<OAuth2Response> oAuth2Response = Single.create(emitter -> oauth2Resource.introspect(accessToken, emitter::onSuccess));
-        return oAuth2Response
-            .map(TokenIntrospectionResult::new)
-            .doOnSuccess(tokenIntrospectionResult ->
-                fillTokenIntrospectionCache(accessToken, oauth2Resource, tokenIntrospectionCache, policyCache, tokenIntrospectionResult)
-            );
+        return cached.switchIfEmpty(
+            Single.<OAuth2Response>create(emitter -> oauth2Resource.introspect(accessToken, emitter::onSuccess))
+                .map(TokenIntrospectionResult::new)
+                .doOnSuccess(tokenIntrospectionResult ->
+                    fillTokenIntrospectionCache(accessToken, oauth2Resource, tokenIntrospectionCache, policyCache, tokenIntrospectionResult)
+                )
+        );
     }
 
     private Completable introspectAndValidateAccessToken(BaseExecutionContext ctx, String accessToken, OAuth2Resource<?> oauth2Resource) {
@@ -503,14 +501,14 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
         // put the introspection result in internal cache
         tokenIntrospectionCache.put(accessToken, oauth2Resource, tokenIntrospectionResult);
 
-        // put the introspection result in policy cache if configured
+        // put the introspection result in policy cache if configured (fire-and-forget; must not block the event loop)
         if (policyCache != null && tokenIntrospectionResult.isSuccess() && tokenIntrospectionResult.hasValidPayload()) {
             CacheElement element = new CacheElement(accessToken, tokenIntrospectionResult.getOauth2ResponsePayload());
             if (tokenIntrospectionResult.hasExpirationTime()) {
                 long ttl = tokenIntrospectionResult.getExpirationTime() - System.currentTimeMillis() / 1000L;
                 element.setTimeToLive(Long.valueOf(ttl).intValue());
             }
-            policyCache.put(element);
+            policyCache.putAsync(element).onFailure(err -> log.warn("Failed to store introspection result in cache", err));
         }
     }
 }

--- a/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3.java
@@ -35,7 +35,6 @@ import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
 import io.gravitee.policy.oauth2.resource.CacheElement;
 import io.gravitee.resource.api.ResourceManager;
 import io.gravitee.resource.cache.api.CacheResource;
-import io.gravitee.resource.cache.api.Element;
 import io.gravitee.resource.oauth2.api.OAuth2Resource;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import java.io.IOException;
@@ -133,13 +132,21 @@ public class Oauth2PolicyV3 {
             .getResource(oAuth2PolicyConfiguration.getOauthCacheResource(), CacheResource.class);
 
         if (cacheResource != null) {
-            Element element = cacheResource.getCache(executionContext).get(accessToken);
-            if (element != null) {
-                String oauth2payload = (String) element.value();
-                handleSuccess(policyChain, request, response, executionContext, oauth2payload, null);
-            } else {
-                oauth2.introspect(accessToken, handleResponse(policyChain, request, response, executionContext, cacheResource));
-            }
+            // async cache lookup — must not block the event loop
+            cacheResource
+                .getCache(executionContext)
+                .getAsync(accessToken)
+                .onComplete(ar -> {
+                    if (ar.succeeded() && ar.result() != null) {
+                        String oauth2payload = (String) ar.result().value();
+                        handleSuccess(policyChain, request, response, executionContext, oauth2payload, null);
+                    } else {
+                        if (ar.failed()) {
+                            logger.warn("Failed to read access token from cache, falling back to introspection", ar.cause());
+                        }
+                        oauth2.introspect(accessToken, handleResponse(policyChain, request, response, executionContext, cacheResource));
+                    }
+                });
         } else {
             // Validate access token
             oauth2.introspect(accessToken, handleResponse(policyChain, request, response, executionContext, null));
@@ -233,7 +240,11 @@ public class Oauth2PolicyV3 {
                 long ttl = expTimestamp - System.currentTimeMillis() / 1000L;
                 element.setTimeToLive(Long.valueOf(ttl).intValue());
             }
-            cacheResource.getCache(executionContext).put(element);
+            // fire-and-forget async put — must not block the event loop
+            cacheResource
+                .getCache(executionContext)
+                .putAsync(element)
+                .onFailure(err -> logger.warn("Failed to store introspection result in cache", err));
         }
 
         if (!oAuth2PolicyConfiguration.isPropagateAuthHeader()) {

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -78,6 +78,7 @@ import io.gravitee.resource.oauth2.api.OAuth2ResourceException;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.Future;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -435,7 +436,7 @@ class Oauth2PolicyTest {
         obs.assertComplete();
 
         verify(ctx).setAttribute(Oauth2Policy.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
-        verify(cache).put(
+        verify(cache).putAsync(
             argThat(e -> {
                 assertEquals(token, e.key());
                 assertEquals(payload, e.value());
@@ -448,6 +449,9 @@ class Oauth2PolicyTest {
         when(configuration.getOauthCacheResource()).thenReturn(OAUTH_CACHE_RESOURCE);
         when(cacheResource.getCache(any(BaseExecutionContext.class))).thenReturn(cache);
         when(resourceManager.getResource(OAUTH_CACHE_RESOURCE, CacheResource.class)).thenReturn(cacheResource);
+        // Default: cache miss for any key, and successful put — override per-test for hit cases
+        lenient().when(cache.getAsync(any())).thenReturn(Future.succeededFuture(null));
+        lenient().when(cache.putAsync(any())).thenReturn(Future.succeededFuture());
     }
 
     @Test
@@ -465,7 +469,7 @@ class Oauth2PolicyTest {
         obs.assertComplete();
 
         verify(ctx).setAttribute(Oauth2Policy.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
-        verify(cache).put(
+        verify(cache).putAsync(
             argThat(e -> {
                 assertEquals(token, e.key());
                 assertEquals(payload, e.value());
@@ -484,7 +488,7 @@ class Oauth2PolicyTest {
         final String payload = readResource("/io/gravitee/policy/oauth2/oauth2-response04.json");
         final CacheElement cacheElement = new CacheElement(token, payload);
 
-        when(cache.get(token)).thenReturn(cacheElement);
+        when(cache.getAsync(token)).thenReturn(Future.succeededFuture(cacheElement));
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertComplete();

--- a/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/oauth2/Oauth2PolicyV3Test.java
@@ -38,6 +38,7 @@ import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.cache.api.Element;
 import io.gravitee.resource.oauth2.api.OAuth2Resource;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
+import io.vertx.core.Future;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -224,7 +225,7 @@ class Oauth2PolicyV3Test {
         JsonNode jsonNode = readJsonResource("/io/gravitee/policy/oauth2/oauth2-response07.json");
         when(cacheElement.value()).thenReturn(jsonNode.toPrettyString());
         Cache cache = mock(Cache.class);
-        when(cache.get(eq(bearer))).thenReturn(cacheElement);
+        when(cache.getAsync(eq(bearer))).thenReturn(Future.succeededFuture(cacheElement));
         when(customCacheResource.getCache(any(ExecutionContext.class))).thenReturn(cache);
 
         when(mockExecutionContext.getTemplateEngine()).thenReturn(templateEngine);
@@ -506,6 +507,7 @@ class Oauth2PolicyV3Test {
 
         Cache cache = mock(Cache.class);
         when(customCacheResource.getCache(any(ExecutionContext.class))).thenReturn(cache);
+        when(cache.putAsync(any(Element.class))).thenReturn(Future.succeededFuture());
 
         Oauth2PolicyV3 policy = new Oauth2PolicyV3(oAuth2PolicyConfiguration);
         Handler<OAuth2Response> handler = policy.handleResponse(
@@ -521,7 +523,7 @@ class Oauth2PolicyV3Test {
 
         verify(mockExecutionContext).setAttribute(Oauth2PolicyV3.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
         verify(mockPolicychain).doNext(mockRequest, mockResponse);
-        verify(cache).put(any(Element.class));
+        verify(cache).putAsync(any(Element.class));
     }
 
     @Test
@@ -537,6 +539,7 @@ class Oauth2PolicyV3Test {
 
         Cache cache = mock(Cache.class);
         when(customCacheResource.getCache(any(ExecutionContext.class))).thenReturn(cache);
+        when(cache.putAsync(any(Element.class))).thenReturn(Future.succeededFuture());
 
         Oauth2PolicyV3 policy = new Oauth2PolicyV3(oAuth2PolicyConfiguration);
         Handler<OAuth2Response> handler = policy.handleResponse(
@@ -554,7 +557,7 @@ class Oauth2PolicyV3Test {
 
         verify(mockExecutionContext).setAttribute(Oauth2PolicyV3.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");
         verify(mockPolicychain).doNext(mockRequest, mockResponse);
-        verify(cache).put(any(Element.class));
+        verify(cache).putAsync(any(Element.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Migrates `Oauth2Policy` (v4) and `Oauth2PolicyV3` (legacy) from the blocking `Cache#get` / `Cache#put` SPI to the async variants (`getAsync` / `putAsync`) added in `gravitee-resource-cache-provider-api` 2.1.0.

Sync `Cache#get`/`Cache#put` on the Vert.x event loop was fine while the cache backend was in-memory, but against `cache-redis` ≥ 4.1.0 it parks the event loop in `CompletableFuture.join()` — because the Vert.x Redis client's Netty loops share the gateway's event-loop group, concurrent introspection requests self-deadlock until `commandTimeoutMs`. See APIM-13700 for the reproduction (8 parallel Bearer requests → 1560 BlockedThreadChecker events and 107 s hang on cache-redis 4.1.0).

## Changes

- **`Oauth2Policy.introspectAccessToken`** — replace `policyCache.get(...)` with `Maybe.fromCompletionStage(policyCache.getAsync(...).toCompletionStage())`, composed via `switchIfEmpty(introspect + fill)`. No blocking on the event loop.
- **`Oauth2Policy.fillTokenIntrospectionCache`** — `policyCache.put(...)` → `policyCache.putAsync(...).onFailure(log)` fire-and-forget.
- **`Oauth2PolicyV3.onRequest`** — `cache.get(...)` → `cache.getAsync(...).onComplete(ar -> hit ? handleSuccess : introspect)`. On async cache-read error, logs a warn and falls through to live introspection (was: bubbled out of `onRequest`).
- **`Oauth2PolicyV3.handleSuccess`** — `cache.put(...)` → `cache.putAsync(...).onFailure(log)`.
- **Tests** — mocks updated: `cache.get` → `cache.getAsync` returning `Future.succeededFuture(...)`; `cache.put` verifications → `cache.putAsync`.

## Not breaking, but note

- Config schema unchanged (`oauthCacheResource` untouched).
- `Cache#getAsync`/`putAsync` are default methods on the SPI interface → no ABI break on cache-provider-api.
- Fixes a deadlock; nothing that worked before stops working.
- **Runtime floor:** plugin now calls methods that only exist in `cache-provider-api` ≥ 2.1.0. Dropping this plugin into a gateway shipping an older cache-provider-api would fail with `NoSuchMethodError`. Matches APIM ≥ 4.11 floor (same as APIM-13557 / APIM-13558).
- **Minor v3 semantic diff:** a cache *read error* in `Oauth2PolicyV3` used to bubble out of `onRequest`; now logs a warn and falls through to introspection. Arguably more correct.

## Related

- Parent epic: APIM-13553 (Redis Cache Resource Vert.x rewrite)
- Bug: APIM-13700 (deadlock repro + fix sketch)
- Sibling policy migrations: APIM-13557 (`gravitee-policy-cache`), APIM-13558 (`gravitee-policy-data-cache`)

## Test plan

- [x] `mvn test` — 103/103 passing locally (including v3 integration tests)
- [ ] CI green
- [ ] Verify in a reproduction instance (8 parallel Bearer requests against cache-redis ≥ 4.1.0 → 0 BlockedThreadChecker events, sub-second latency)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.3.0-wba-APIM-13700-oauth2-async-cache-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/5.3.0-wba-APIM-13700-oauth2-async-cache-SNAPSHOT/gravitee-policy-oauth2-5.3.0-wba-APIM-13700-oauth2-async-cache-SNAPSHOT.zip)
  <!-- Version placeholder end -->
