### PR TITLE
fix: support path-based well-known form

### DIFF
--- a/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
+++ b/src/main/java/io/gravitee/policy/oauth2/Oauth2Policy.java
@@ -242,29 +242,43 @@ public class Oauth2Policy extends Oauth2PolicyV3 implements HttpSecurityPolicy, 
     @Override
     public Single<Boolean> onWellKnown(final HttpPlainExecutionContext ctx) {
         URI uri = URI.create(ctx.getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL));
-        if (uri.getRawPath().startsWith(WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH)) {
-            final OAuth2Resource<?> oauth2Resource = getOauth2Resource(ctx);
-            String protectedResourceUri =
-                uri.getScheme() +
-                "://" +
-                uri.getRawAuthority() +
-                uri.getRawPath().substring(WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH.length());
+        String rawPath = uri.getRawPath();
 
-            List<String> scopesSupported = oAuth2PolicyConfiguration.getRequiredScopes() != null
-                ? oAuth2PolicyConfiguration.getRequiredScopes()
-                : List.of();
-            OAuth2ResourceMetadata resourceMetadata = oauth2Resource.getProtectedResourceMetadata(protectedResourceUri, scopesSupported);
-
-            try {
-                String message = MAPPER.writeValueAsString(resourceMetadata);
-                ctx.response().body(Buffer.buffer(message));
-                return Single.just(true);
-            } catch (JsonProcessingException e) {
-                log.error("Unable to serialize OAuth2 resource metadata", e);
-                return Single.just(false);
-            }
+        String protectedResourcePath;
+        if (rawPath.startsWith(WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH)) {
+            // §3.1 inserted form: /.well-known/oauth-protected-resource/my-api
+            protectedResourcePath = rawPath.substring(WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH.length());
+        } else if (rawPath.endsWith(WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH)) {
+            // Path-based form: /my-api/.well-known/oauth-protected-resource
+            protectedResourcePath = rawPath.substring(0, rawPath.length() - WELL_KNOWN_OAUTH_PROTECTED_RESOURCE_PATH.length());
+        } else {
+            return Single.just(false);
         }
-        return Single.just(false);
+
+        if (protectedResourcePath.isEmpty()) {
+            protectedResourcePath = "/";
+        }
+        String protectedResourceUri = uri.getScheme() + "://" + uri.getRawAuthority() + protectedResourcePath;
+
+        final OAuth2Resource<?> oauth2Resource = getOauth2Resource(ctx);
+        if (oauth2Resource == null) {
+            return Single.just(false);
+        }
+
+        List<String> scopesSupported = oAuth2PolicyConfiguration.getRequiredScopes() != null
+            ? oAuth2PolicyConfiguration.getRequiredScopes()
+            : List.of();
+        OAuth2ResourceMetadata resourceMetadata = oauth2Resource.getProtectedResourceMetadata(protectedResourceUri, scopesSupported);
+
+        try {
+            String message = MAPPER.writeValueAsString(resourceMetadata);
+            ctx.response().headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+            ctx.response().body(Buffer.buffer(message));
+            return Single.just(true);
+        } catch (JsonProcessingException e) {
+            log.error("Unable to serialize OAuth2 resource metadata", e);
+            return Single.just(false);
+        }
     }
 
     private Maybe<SecurityToken> getSecurityTokenFromContext(BaseExecutionContext ctx) {

--- a/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
+++ b/src/test/java/io/gravitee/policy/oauth2/Oauth2PolicyTest.java
@@ -75,6 +75,7 @@ import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.oauth2.api.OAuth2Resource;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceException;
+import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -648,6 +649,110 @@ class Oauth2PolicyTest {
             HttpHeaderNames.WWW_AUTHENTICATE,
             "Bearer resource_metadata=\"https://example.com/.well-known/oauth-protected-resource/my-api\" scope=\"read write\""
         );
+    }
+
+    @Test
+    void onWellKnownShouldRespondForInsertedForm() {
+        when(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL)).thenReturn(
+            "https://example.com/.well-known/oauth-protected-resource/my-api"
+        );
+        prepareOauth2Resource();
+
+        OAuth2ResourceMetadata metadata = new OAuth2ResourceMetadata(
+            "https://example.com/my-api",
+            List.of("https://auth.example.com"),
+            List.of()
+        );
+        when(oAuth2Resource.getProtectedResourceMetadata("https://example.com/my-api", List.of())).thenReturn(metadata);
+
+        final TestObserver<Boolean> obs = cut.onWellKnown(ctx).test();
+        obs.assertComplete().assertValue(true);
+
+        verify(response).body(any(io.gravitee.gateway.api.buffer.Buffer.class));
+        verify(responseHeaders).set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+    }
+
+    @Test
+    void onWellKnownShouldRespondForPathBasedForm() {
+        when(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL)).thenReturn(
+            "https://example.com/my-api/.well-known/oauth-protected-resource"
+        );
+        prepareOauth2Resource();
+
+        OAuth2ResourceMetadata metadata = new OAuth2ResourceMetadata(
+            "https://example.com/my-api",
+            List.of("https://auth.example.com"),
+            List.of()
+        );
+        when(oAuth2Resource.getProtectedResourceMetadata("https://example.com/my-api", List.of())).thenReturn(metadata);
+
+        final TestObserver<Boolean> obs = cut.onWellKnown(ctx).test();
+        obs.assertComplete().assertValue(true);
+
+        verify(response).body(any(io.gravitee.gateway.api.buffer.Buffer.class));
+        verify(responseHeaders).set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+    }
+
+    @Test
+    void onWellKnownShouldReturnFalseForUnrelatedPath() {
+        when(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL)).thenReturn("https://example.com/my-api/some-path");
+
+        final TestObserver<Boolean> obs = cut.onWellKnown(ctx).test();
+        obs.assertComplete().assertValue(false);
+
+        verify(response, never()).body(any(io.gravitee.gateway.api.buffer.Buffer.class));
+    }
+
+    @Test
+    void onWellKnownShouldReturnFalseWhenNoOAuth2Resource() {
+        when(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL)).thenReturn(
+            "https://example.com/.well-known/oauth-protected-resource/my-api"
+        );
+        when(configuration.getOauthResource()).thenReturn(null);
+
+        final TestObserver<Boolean> obs = cut.onWellKnown(ctx).test();
+        obs.assertComplete().assertValue(false);
+    }
+
+    @Test
+    void onWellKnownShouldUseRootPathForInsertedFormWithoutSuffix() {
+        when(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL)).thenReturn(
+            "https://example.com/.well-known/oauth-protected-resource"
+        );
+        prepareOauth2Resource();
+
+        OAuth2ResourceMetadata metadata = new OAuth2ResourceMetadata(
+            "https://example.com/",
+            List.of("https://auth.example.com"),
+            List.of()
+        );
+        when(oAuth2Resource.getProtectedResourceMetadata("https://example.com/", List.of())).thenReturn(metadata);
+
+        final TestObserver<Boolean> obs = cut.onWellKnown(ctx).test();
+        obs.assertComplete().assertValue(true);
+
+        verify(response).body(any(io.gravitee.gateway.api.buffer.Buffer.class));
+    }
+
+    @Test
+    void onWellKnownShouldIncludeConfiguredScopes() {
+        when(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL)).thenReturn(
+            "https://example.com/my-api/.well-known/oauth-protected-resource"
+        );
+        prepareOauth2Resource();
+        when(configuration.getRequiredScopes()).thenReturn(List.of("read", "write"));
+
+        OAuth2ResourceMetadata metadata = new OAuth2ResourceMetadata(
+            "https://example.com/my-api",
+            List.of("https://auth.example.com"),
+            List.of("read", "write")
+        );
+        when(oAuth2Resource.getProtectedResourceMetadata("https://example.com/my-api", List.of("read", "write"))).thenReturn(metadata);
+
+        final TestObserver<Boolean> obs = cut.onWellKnown(ctx).test();
+        obs.assertComplete().assertValue(true);
+
+        verify(response).body(any(io.gravitee.gateway.api.buffer.Buffer.class));
     }
 
     private String prepareToken() {


### PR DESCRIPTION
The onWellKnown handler only matched the RFC 9728 §3.1 inserted form (/.well-known/oauth-protected-resource/my-api) since 0b9cd99. MCP clients (Claude Desktop, Cursor) also probe the path-based form (/my-api/.well-known/oauth-protected-resource) which was left unhandled, causing OAuth discovery to fail on MCP_PROXY APIs.

Add an endsWith branch to match the path-based form, restoring the backward compatibility required by APIM-13396 AC#2. Also set Content-Type: application/json on the response (RFC 9728 requirement).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.3.1-fix-path-based-well-known-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-oauth2/5.3.1-fix-path-based-well-known-SNAPSHOT/gravitee-policy-oauth2-5.3.1-fix-path-based-well-known-SNAPSHOT.zip)
  <!-- Version placeholder end -->
